### PR TITLE
amend python env to use `#!/usr/bin/env python`

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 from __future__ import print_function
 
 import distutils.spawn


### PR DESCRIPTION
amend python env to use `#!/usr/bin/env python` instead of `python3` for better compatibility