### PR TITLE
Add a space after the tick

### DIFF
--- a/install.py
+++ b/install.py
@@ -24,9 +24,9 @@ def hookpath():
 run("git config --global core.hooksPath " + hookpath())
 
 print()
-print("✔️ Detect-secrets hook installed")
+print("✔️  Detect-secrets hook installed")
 
 register("test")  # Remove test mode argument for production
 
 print()
-print("✔️ User registered")
+print("✔️  User registered")


### PR DESCRIPTION
In bash the tick is rendered like an emoji and there is a lack of space which looks bleugh.
It's a tiny thing but I dislike it :upside_down_face: 

_top example is this branch, bottom is current master_
![screenshot](https://imgur.com/F8o0LOB.png)