### PR TITLE
install: If we can't find pip, print to stderr and exit

### DIFF
--- a/install.py
+++ b/install.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import distutils.spawn
 import os
+import sys
 
 from register import register
 from runner import run
@@ -14,7 +15,8 @@ if distutils.spawn.find_executable("pip3"):
 elif distutils.spawn.find_executable("pip"):
     run("pip install -q pre-commit detect-secrets")
 else:
-    print("Can't find `pip` or `pip3` on your PATH, please install pip.")
+    print("Can't find `pip` or `pip3` on your PATH, please install pip.", file=sys.stderr)
+    sys.exit(1)
 
 
 def hookpath():


### PR DESCRIPTION
Don't just keep going and say it installed.