### PR TITLE
Catch json errors in python2

### DIFF
--- a/register.py
+++ b/register.py
@@ -63,7 +63,7 @@ def register(mode="prod"):
             authorization = json.loads(authorization_json)
             token = authorization["token"]
             run("git config --global gds.github-registration-token " + token)
-        except json.JSONDecodeError:
+        except:
             print("Failed to authenticate with GitHub.")
             print("Please check your credentials and try again.")
             sys.exit(1)


### PR DESCRIPTION
Python 2 doesn't have json encoding errors, so I guess we have to catch-all?