### PR TITLE
add a custom warning message

### DIFF
--- a/global_install/hooks/pre-commit.py
+++ b/global_install/hooks/pre-commit.py
@@ -31,6 +31,8 @@ INSTALL_PYTHON = "/usr/local/Cellar/pre-commit/1.20.0/libexec/bin/python3.7"
 SKIP_ON_MISSING_CONFIG = False
 # end templated
 
+os.environ["DETECT_SECRETS_SECURITY_TEAM"] = "in #cyber-security-help"
+
 
 class EarlyExit(RuntimeError):
     pass


### PR DESCRIPTION
Now that yelp have cut a release of detect-secrets with our paramaterised messaging feature, I've modified our hook to use it, we now get a message that correctly says `For information about putting your secrets in a safer place, please ask in #cyber-security-help`

:ok_hand: 

Full message:
```
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to /home/oatman/.cache/pre-commit/patch1585580727.
Detect Private Key.......................................................Passed
Detect secrets...........................................................Failed
- hook id: detect-secrets
- exit code: 1

Potential secrets about to be committed to git repo! Please rectify or
explicitly ignore with an inline `pragma: allowlist secret` comment.

Secret Type: Secret Keyword
Location:    pass.py:1

Possible mitigations:

  - For information about putting your secrets in a safer place,
    please ask in #cyber-security-help
  - Mark false positives with an inline `pragma: allowlist secret`
    comment
  - Commit with `--no-verify` if this is a one-time false positive

If a secret has already been committed, visit
https://help.github.com/articles/removing-sensitive-data-from-a-
repository

[INFO] Restored changes from /home/oatman/.cache/pre-commit/patch1585580727.
```