### PR TITLE
Use hexsha instead of active_branch to work around detached head

### DIFF
--- a/test-detection/detect_checker.py
+++ b/test-detection/detect_checker.py
@@ -10,7 +10,6 @@ import boto3
 import fire
 import git
 
-
 def get_paged_ssm_params(path: str) -> list:
     """ Get SSM parameters into single array from 10 item pages """
     ssm_client = boto3.client("ssm")
@@ -121,8 +120,8 @@ self.templates """
 
     def _load_repo(self):
         self.repo = git.repo.base.Repo("..")
-        self.parent_branch = self.repo.active_branch
-        print(f"Currently on branch: {self.parent_branch.name}")
+        self.parent_branch = self.repo.head.object.hexsha
+        print(f"Currently on branch: {self.parent_branch}")
         return self.repo
 
     def _checkout_test_branch(self):
@@ -138,7 +137,7 @@ self.templates """
     def _delete_test_branch(self):
         """ Delete local test branch """
         self._restore_ignore_file()
-        self.parent_branch.checkout()
+        self.repo.head.reference = self.parent_branch
         self.repo.delete_head(self.branch_name, force=True)
 
     def _test_commit(self, example_file: str) -> bool:
@@ -192,7 +191,7 @@ detect-secrets """
                     test["outcome"] = outcome
 
             self._delete_test_branch()
-            print(f"Reset to parent branch: {self.repo.active_branch.name}")
+            print(f"Reset to parent branch: {self.repo.head.object.hexsha}")
 
             language_stats = defaultdict(dict)
             secret_stats = defaultdict(dict)


### PR DESCRIPTION
When concourse checks out a repo it leaves it in a detached head
state. This was causing errors as python git has slightly undefined
behaviour in this case.

```
File "detect_checker.py", line 125, in _load_repo
    self.parent_branch = self.repo.active_branch
File "/home/a/venv/local/lib/python3.7/site-packages/git/repo/base.py", line 703, in active_branch
    return self.head.reference
File "/home/a/venv/local/lib/python3.7/site-packages/git/refs/symbolic.py", line 272, in _get_reference
    raise TypeError("%s is a detached symbolic reference as it points to %r" % (self, sha))
TypeError: HEAD is a detached symbolic reference as it points to '6e589de2864ee310a46a343ae9d656405e6b8c84'
```

https://github.com/gitpython-developers/GitPython/issues/633

This PR changes it use the hexsha instead which works correctly with
detached heads and normal branches.

Co-authored-by: detnon <sam.detnon@digital.cabinet-office.gov.uk>
Co-authored-by: Alex Kinnane <17098249+akinnane@users.noreply.github.com>