### PR TITLE
change `detect-secrets scan` call to action

### DIFF
--- a/global_install/hooks/pre-commit.py
+++ b/global_install/hooks/pre-commit.py
@@ -213,7 +213,7 @@ def main():
     if not os.path.isfile(baseline_path):
         print("Unable to open baseline file: `REPO_ROOT`/.secrets.baseline")
         print("Please create it via")
-        print("   `detect-secrets scan > " + baseline_path + "`")
+        print("   detect-secrets scan > .secrets.baseline")
         sys.exit(1)
 
     retv, stdin = _run_legacy()


### PR DESCRIPTION
Two changes:

1) I found the backticks were hostile to copy-pasting the command, so
I removed them

2) I found it worrying that the absolute path of the .secrets.baseline
was there, because this feels like a footgun when you accidentally run
the command in the wrong repository.  `detect-secrets scan` scans the
current directory, so it should output in the current directory too.