### PR TITLE
Pin to git hashes - not tags

### DIFF
--- a/global_install/hooks/.pre-commit-config.yaml
+++ b/global_install/hooks/.pre-commit-config.yaml
@@ -2,11 +2,11 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: d6d3bd94604578adbd918c5a00d531d98350d86f # v2.3.0
     hooks:
     -   id: detect-private-key
 -   repo: git@github.com:Yelp/detect-secrets
-    rev: v0.13.1
+    rev: a3e7998bfa4924b13df3f9cb49070abdbdff8802 # v0.13.1
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']


### PR DESCRIPTION
Git tags are mutable. This means that if either of the repositories were compromised, an attacker could push a new version of the tag that contained malicious code. Instead, pin to the git hash, which is immutable. Retain the tag in a comment for readability.

Note that in both cases the release we're using is not the latest. I don't propose to address that here, though.