### PR TITLE
Use HTTPS for GitHub URL

### DIFF
--- a/global_install/hooks/.pre-commit-config.yaml
+++ b/global_install/hooks/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     rev: d6d3bd94604578adbd918c5a00d531d98350d86f # v2.3.0
     hooks:
     -   id: detect-private-key
--   repo: git@github.com:Yelp/detect-secrets
+-   repo: https://github.com/Yelp/detect-secrets
     rev: a3e7998bfa4924b13df3f9cb49070abdbdff8802 # v0.13.1
     hooks:
     -   id: detect-secrets


### PR DESCRIPTION
Some people might not have a SSH key setup when using precommit.