### PR TITLE
Record personal information sent to GDS Cyber team

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,16 @@ repositories by looking for the baseline file.
 Neither of those on their own give us a good idea of how many 
 commits are being made against alphagov without protection so 
 hopefully in time we can actually report by commit with another 
-hook. 
+hook.
+
+## Privacy
+
+By installing this tool, you will send the GDS Cyber team:
+
+* your name as configured in your global git configuration
+* your email address as configured in your global git configuration
+* your IP address
+* the version of curl installed on your machine
 
 ## Further Reading
 


### PR DESCRIPTION
Make explicit what personal information a user sends to the GDS Cyber team by installing this tool. I don't know what information Cyber actually stores/processes, so I've included everything. Feel free to amend if we don't collect all the information sent.

We'd need to expand it further to become a proper privacy notice. I don't know enough about how the data is used to do so, though. This is probably a good start.