### PR TITLE
Detect and fail on non-system (ie pyenv, venv) interpreters

### DIFF
--- a/install.py
+++ b/install.py
@@ -4,9 +4,13 @@ from __future__ import print_function
 import sys
 import os
 
-if "pyenv" in sys.executable:
-    print("pyenv interpreter detected, please install with your system python")
+def detect(subpath, error):  
+    if subpath in sys.executable:
+    print(error)
     sys.exit(1)
+
+detect("pyenv", "pyenv interpreter detected, please install with your system python")
+detect("virtualenvs", "virtualenvironment interpreter detected, please install with your system python")
 
 from register import register
 from runner import run

--- a/install.py
+++ b/install.py
@@ -1,26 +1,36 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function
-import sys
+
 import os
-
-def detect(subpath, error):  
-    if subpath in sys.executable:
-    print(error)
-    sys.exit(1)
-
-detect("pyenv", "pyenv interpreter detected, please install with your system python")
-detect("virtualenvs", "virtualenvironment interpreter detected, please install with your system python")
+import sys
 
 from register import register
 from runner import run
+
+
+def detect(subpath, error):
+    "if `subpath` found in the executable path, print `error` and exit."
+    if subpath in sys.executable:
+        print(error)
+        sys.exit(1)
+
+
+detect("pyenv", "pyenv interpreter detected, please install with your system python")
+detect(
+    "virtualenvs",
+    "virtualenvironment interpreter detected, please install with your system python",
+)
+
 
 try:
     input = raw_input  # type: ignore
 except NameError:
     pass
 
+
 def hookpath():
+    "Returns the absolute path to the hooks directory"
     p = os.path.dirname(os.path.realpath(__file__))
     return os.path.join(p, "global_install", "hooks")
 

--- a/install.py
+++ b/install.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function
-
+import sys
 import os
+
+if "pyenv" in sys.executable:
+    print("pyenv interpreter detected, please install with your system python")
+    sys.exit(1)
 
 from register import register
 from runner import run


### PR DESCRIPTION
A common failure pattern is to install detect-secrets using a non-system-wide python version. 
The installer now detects this and bails.