### PR TITLE
fix example config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ hook.
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
-        exclude: .*/tests/.*
+        exclude: .*/hashes/.*
 ```
 
 ## Privacy


### PR DESCRIPTION
shouldn't ignore secrets in tests - this has already been reported to Yelp