### PR TITLE
Macify git command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ However this has a few surprising edge-cases:
 Only one thing is needed to disable our old, customised, version of the pre-commit framework - remove the global pre-commit hook from git:
 
 ``` shell
-git global config --unset-all core.hooksPath
+git --global config --unset-all core.hooksPath
 ```
 
 This will not touch the files in the default install path of `~/.gds.pre-commit`. To finish the cleanup, remove this directory.


### PR DESCRIPTION
As most of our users are on mac, the command should really be the mac command.