### PR TITLE
bump versions of pre-commit-hooks and detect-secrets

### DIFF
--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -2,11 +2,11 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: d6d3bd94604578adbd918c5a00d531d98350d86f # v2.3.0
+    rev: 9136088a246768144165fcc3ecc3d31bb686920a # v3.3.0
     hooks:
     -   id: detect-private-key
 -   repo: https://github.com/Yelp/detect-secrets
-    rev: a3e7998bfa4924b13df3f9cb49070abdbdff8802 # v0.13.1
+    rev: c09b466f7600e35e093c5da0437eca74a7c7a459 # v0.14.3
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']

--- a/pre-commit-plugins.md
+++ b/pre-commit-plugins.md
@@ -9,7 +9,6 @@ Please note that these hooks are found on the pre-commit website but have not al
 * `check-yaml`
 * `pretty-format-json`
 * `check-merge-conflict`
-* `flake8`
 
 ### Python hooks
 [github.com/pre-commit/pygrep-hooks](https://github.com/pre-commit/pygrep-hooks)
@@ -21,6 +20,9 @@ Please note that these hooks are found on the pre-commit website but have not al
 
 * `bandit`
 
+https://gitlab.com/pycqa/flake8
+
+*`flake8`
 
 ### Ruby hooks
 [github.com/chriskuehl/puppet-pre-commit-hooks](https://github.com/chriskuehl/puppet-pre-commit-hooks)


### PR DESCRIPTION
I installed a newer version and now I keep fighting with checked-in
`.secrets.baseline` files that were generated by an older version.

Pre-commit-hooks 3.0 dropped their own `flake8` hook, they say to now
use flake8 directly.  See
https://github.com/pre-commit/pre-commit-hooks/releases/tag/v3.0.0